### PR TITLE
push table styling to kadence table patterns

### DIFF
--- a/_source/scss/base/_basic-elements.scss
+++ b/_source/scss/base/_basic-elements.scss
@@ -50,3 +50,33 @@ figure {
     margin-bottom: 0;
   }
 }
+
+/* - Kadence table styles - */
+.kb-table-container {
+  //
+  &.hc-table {
+    //
+    th p,
+    td p {
+      margin-block-start: unset;
+      margin-block-end: unset;
+    }
+    //
+    td {
+      vertical-align: top;
+    }
+
+    &.is-alternating {
+      tr:not(:has(th)) {
+        &:nth-child(even) {
+          background-color: var(--wp--preset--color--neutral);
+        }
+
+        &:nth-child(odd) {
+          background-color: var(--wp--preset--color--base);
+        }
+      }
+    }
+  }
+  //
+}


### PR DESCRIPTION
Added a custom class `.hc-table` to our Kadence table to keep code exclusive. For alternating table row styles, add the `.is-alternating` class.

Alternating styles via the Kadence UI conflicts with the custom header color, so styling needs to apply via code. With that said, alternating colors will only show on live, not in the editor

When merged, changes can be seen here: https://interpaystg.wpenginepowered.com/how-interpayments-helped-a-metals-distributor-protect-margins-on-digital-business-clone/